### PR TITLE
add an additional view to preview all the colors in the category

### DIFF
--- a/ColoursDemo/ColoursDemo.xcodeproj/project.pbxproj
+++ b/ColoursDemo/ColoursDemo.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		C06758E116F691E000CE7AA1 /* icon114.png in Resources */ = {isa = PBXBuildFile; fileRef = C06758DF16F691E000CE7AA1 /* icon114.png */; };
 		C06758E316F691F500CE7AA1 /* icon57.png in Resources */ = {isa = PBXBuildFile; fileRef = C06758E216F691F500CE7AA1 /* icon57.png */; };
 		C06758E516F691F900CE7AA1 /* icon114.png in Resources */ = {isa = PBXBuildFile; fileRef = C06758E416F691F900CE7AA1 /* icon114.png */; };
+		D326F23C179B19BA0082A676 /* ColorsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D326F23B179B19BA0082A676 /* ColorsViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +51,8 @@
 		C06758DF16F691E000CE7AA1 /* icon114.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon114.png; sourceTree = "<group>"; };
 		C06758E216F691F500CE7AA1 /* icon57.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon57.png; sourceTree = "<group>"; };
 		C06758E416F691F900CE7AA1 /* icon114.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon114.png; sourceTree = "<group>"; };
+		D326F23A179B19BA0082A676 /* ColorsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorsViewController.h; sourceTree = "<group>"; };
+		D326F23B179B19BA0082A676 /* ColorsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ColorsViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +111,8 @@
 				C06758CE16F6824200CE7AA1 /* ViewController.m */,
 				C06758D016F6824200CE7AA1 /* ViewController.xib */,
 				C06758BC16F6824200CE7AA1 /* Supporting Files */,
+				D326F23A179B19BA0082A676 /* ColorsViewController.h */,
+				D326F23B179B19BA0082A676 /* ColorsViewController.m */,
 			);
 			path = ColoursDemo;
 			sourceTree = "<group>";
@@ -202,6 +207,7 @@
 				C06758C616F6824200CE7AA1 /* AppDelegate.m in Sources */,
 				C06758CF16F6824200CE7AA1 /* ViewController.m in Sources */,
 				0935EC3E170D6BD200DCA335 /* UIColor+Colours.m in Sources */,
+				D326F23C179B19BA0082A676 /* ColorsViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ColoursDemo/ColoursDemo/AppDelegate.m
+++ b/ColoursDemo/ColoursDemo/AppDelegate.m
@@ -9,6 +9,7 @@
 #import "AppDelegate.h"
 
 #import "ViewController.h"
+#import "ColorsViewController.h"
 
 @implementation AppDelegate
 
@@ -17,7 +18,15 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
     self.viewController = [[ViewController alloc] initWithNibName:@"ViewController" bundle:nil];
-    self.window.rootViewController = self.viewController;
+    self.viewController.tabBarItem.title = @"Demo";
+
+    ColorsViewController *colorsController = [[ColorsViewController alloc] initWithStyle:UITableViewStylePlain];
+    colorsController.tabBarItem.title = @"Colors";
+
+    UITabBarController *tab = [[UITabBarController alloc] init];
+    tab.viewControllers = @[self.viewController, colorsController];
+
+    self.window.rootViewController = tab;
     [self.window makeKeyAndVisible];
     return YES;
 }

--- a/ColoursDemo/ColoursDemo/ColorsViewController.h
+++ b/ColoursDemo/ColoursDemo/ColorsViewController.h
@@ -1,0 +1,13 @@
+//
+//  ColorsViewController.h
+//  ColoursDemo
+//
+//  Created by Brian Partridge on 7/20/13.
+//  Copyright (c) 2013 Ben Gordon. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ColorsViewController : UITableViewController
+
+@end

--- a/ColoursDemo/ColoursDemo/ColorsViewController.m
+++ b/ColoursDemo/ColoursDemo/ColorsViewController.m
@@ -1,0 +1,191 @@
+//
+//  ColorsViewController.m
+//  ColoursDemo
+//
+//  Created by Brian Partridge on 7/20/13.
+//  Copyright (c) 2013 Ben Gordon. All rights reserved.
+//
+
+#import "ColorsViewController.h"
+
+@interface ColorsViewController ()
+
+@property (nonatomic, strong) NSArray *colors;
+
+@end
+
+@implementation ColorsViewController
+
+- (id)initWithStyle:(UITableViewStyle)style
+{
+    self = [super initWithStyle:style];
+    if (self) {
+        // Custom initialization
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    // Uncomment the following line to preserve selection between presentations.
+    // self.clearsSelectionOnViewWillAppear = NO;
+
+    // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+    // self.navigationItem.rightBarButtonItem = self.editButtonItem;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    
+    self.colors = @[@"infoBlue",
+                    @"success",
+                    @"warning",
+                    @"danger",
+                    @"antiqueWhite",
+                    @"oldLace",
+                    @"ivory",
+                    @"seashell",
+                    @"ghostWhite",
+                    @"snow",
+                    @"linen",
+                    @"black25Percent",
+                    @"black50Percent",
+                    @"black75Percent",
+                    @"warmGray",
+                    @"coolGray",
+                    @"charcoal",
+                    @"teal",
+                    @"steelBlue",
+                    @"robinEgg",
+                    @"pastelBlue",
+                    @"turquoise",
+                    @"skyeBlue",
+                    @"indigo",
+                    @"denim",
+                    @"blueberry",
+                    @"cornflower",
+                    @"babyBlue",
+                    @"midnightBlue",
+                    @"fadedBlue",
+                    @"iceberg",
+                    @"wave",
+                    @"emerald",
+                    @"grass",
+                    @"pastelGreen",
+                    @"seafoam",
+                    @"paleGreen",
+                    @"cactusGreen",
+                    @"chartreuse",
+                    @"hollyGreen",
+                    @"olive",
+                    @"oliveDrab",
+                    @"moneyGreen",
+                    @"honeydew",
+                    @"lime",
+                    @"cardTable",
+                    @"salmon",
+                    @"brickRed",
+                    @"easterPink",
+                    @"grapefruit",
+                    @"pink",
+                    @"indianRed",
+                    @"strawberry",
+                    @"coral",
+                    @"maroon",
+                    @"watermelon",
+                    @"tomato",
+                    @"pinkLipstick",
+                    @"paleRose",
+                    @"crimson",
+                    @"eggplant",
+                    @"pastelPurple",
+                    @"palePurple",
+                    @"coolPurple",
+                    @"violet",
+                    @"plum",
+                    @"lavender",
+                    @"raspberry",
+                    @"fuschia",
+                    @"grape",
+                    @"periwinkle",
+                    @"orchid",
+                    @"goldenrod",
+                    @"yellowGreen",
+                    @"banana",
+                    @"mustard",
+                    @"buttermilk",
+                    @"gold",
+                    @"cream",
+                    @"lightCream",
+                    @"wheat",
+                    @"beige",
+                    @"peach",
+                    @"burntOrange",
+                    @"pastelOrange",
+                    @"cantaloupe",
+                    @"carrot",
+                    @"mandarin",
+                    @"chiliPowder",
+                    @"burntSienna",
+                    @"chocolate",
+                    @"coffee",
+                    @"cinnamon",
+                    @"almon",
+                    @"eggshell",
+                    @"sand",
+                    @"mud",
+                    @"sienna",
+                    @"dust"];
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - UITableViewDatasource
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.colors.count;
+}
+
+- (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath {
+    NSString *name = [self.colors objectAtIndex:indexPath.row];
+    cell.textLabel.text = name;
+    cell.textLabel.backgroundColor = [UIColor clearColor];
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
+    SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@Color", name]);
+    UIView *background = [[UIView alloc] init];
+    if ([[UIColor class] respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        background.backgroundColor = (UIColor *)[[UIColor class] performSelector:selector];
+#pragma diagnostic pop
+    }
+    cell.backgroundView = background;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    static NSString *CellIdentifier = @"Cell";
+
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
+    }
+
+    [self configureCell:cell atIndexPath:indexPath];
+
+    return cell;
+}
+
+#pragma mark - UITableViewDelegate
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+@end


### PR DESCRIPTION
All the colors are nice, but you only show off a few in the demo screen.  This adds a new screen that shows off all of the colors provided by the category.

![ios simulator screen shot jul 20 2013 3 53 50 pm](https://f.cloud.github.com/assets/47840/830781/2351a2d8-f176-11e2-8896-c04cb9e8053e.png)
