### PR TITLE
Typo fix + Add method for creating color directly from hex number.

### DIFF
--- a/ColoursDemo/ColoursDemo/UIColor+Colours.h
+++ b/ColoursDemo/ColoursDemo/UIColor+Colours.h
@@ -22,8 +22,9 @@ typedef enum
 
 // Color Methods
 + (UIColor *)colorFromHexString:(NSString *)hexString;
++ (UIColor *) colorWithHexNumber:(UInt32)hex andAlpha:(CGFloat)alpha;
 + (UIColor *)colorWithRGBAArray:(NSArray *)rgbaArray;
-+ (UIColor *)colorWithCMKY:(NSArray *)cmykValues;
++ (UIColor *)colorWithCMYK:(NSArray *)cmykValues;
 - (NSString *)hexString;
 - (NSArray *)rgbaArray;//returns the rgba as percents
 - (NSArray *)rgbaValues;//returns rgba as actual rgb values

--- a/ColoursDemo/ColoursDemo/UIColor+Colours.m
+++ b/ColoursDemo/ColoursDemo/UIColor+Colours.m
@@ -12,15 +12,21 @@
 
 #pragma mark - UIColor from Hex
 
-+ (UIColor *)colorFromHexString:(NSString *)hexString
-{
++ (UIColor *)colorFromHexString:(NSString *)hexString {
     unsigned rgbValue = 0;
     hexString = [hexString stringByReplacingOccurrencesOfString:@"#" withString:@""];
     NSScanner *scanner = [NSScanner scannerWithString:hexString];
 	
     [scanner scanHexInt:&rgbValue];
 	
-    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+    return [UIColor colorWithHexNumber:rgbValue andAlpha:1.0];
+}
+
++ (UIColor *) colorWithHexNumber:(UInt32)hex andAlpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:((hex >> 16) & 0xFF) / 255.0
+                           green:((hex >> 8) & 0xFF) / 255.0
+                            blue:(hex & 0xFF) / 255.0
+                           alpha:alpha];
 }
 
 #pragma mark - UIColor from Array
@@ -35,7 +41,7 @@
     return [UIColor colorWithRed:r green:g blue:b alpha:a];
 }
 
-+ (UIColor *)colorWithCMKY:(NSArray *)cmykValues{
++ (UIColor *)colorWithCMYK:(NSArray *)cmykValues{
     int c = [cmykValues[0] floatValue];
     int m = [cmykValues[1] floatValue];
     int y = [cmykValues[2] floatValue];

--- a/ColoursDemo/ColoursDemo/ViewController.m
+++ b/ColoursDemo/ColoursDemo/ViewController.m
@@ -33,7 +33,7 @@
 
 -(void)testCMYKConversion{
     
-    UIColor *blue = [UIColor colorWithCMKY:@[
+    UIColor *blue = [UIColor colorWithCMYK:@[
                      [NSNumber numberWithFloat:1],
                      [NSNumber numberWithFloat:1],
                      [NSNumber numberWithFloat:0],
@@ -42,7 +42,6 @@
     NSLog(@"Blue rgb value should be 0:0:255; Result:%@",blue.rgbaValues);
     NSLog(@"Blue rgb percent should be 0:0:1; Result:%@",blue.rgbaArray);
     NSLog(@"Blue hex should be #0000FF; Result:%@",blue.hexString);
-
 }
 
 #pragma mark - UI for Demo


### PR DESCRIPTION
Typo fix in method name ( _colorWithCMKY_ -> _colorWithCMYK_ ).
Add method for creating color from hex number, I think it's much more useful than parsing hex number from string, at least it's faster.
