### PR TITLE
Fix incompatible pointer type warning in rgbArray, rgbaDictionary, hsbaArray, and hsbaDictionary

### DIFF
--- a/UIColor+Colours.m
+++ b/UIColor+Colours.m
@@ -63,7 +63,7 @@
 - (NSArray *)rgbaArray
 {
     // Takes a UIColor and returns R,G,B,A values in NSNumber form
-    float r=0,g=0,b=0,a=0;
+    CGFloat r=0,g=0,b=0,a=0;
     
     if ([self respondsToSelector:@selector(getRed:green:blue:alpha:)]) {
         [self getRed:&r green:&g blue:&b alpha:&a];
@@ -84,7 +84,7 @@
 - (NSDictionary *)rgbaDictionary
 {
     // Takes UIColor and returns RGBA values in a dictionary as NSNumbers
-    float r=0,g=0,b=0,a=0;
+    CGFloat r=0,g=0,b=0,a=0;
     if ([self respondsToSelector:@selector(getRed:green:blue:alpha:)]) {
         [self getRed:&r green:&g blue:&b alpha:&a];
     }
@@ -104,7 +104,7 @@
 - (NSArray *)hsbaArray
 {
     // Takes a UIColor and returns Hue,Saturation,Brightness,Alpha values in NSNumber form
-    float h=0,s=0,b=0,a=0;
+    CGFloat h=0,s=0,b=0,a=0;
     
     if ([self respondsToSelector:@selector(getHue:saturation:brightness:alpha:)]) {
         [self getHue:&h saturation:&s brightness:&b alpha:&a];
@@ -119,7 +119,7 @@
 - (NSDictionary *)hsbaDictionary
 {
     // Takes a UIColor and returns Hue,Saturation,Brightness,Alpha values in NSNumber form
-    float h=0,s=0,b=0,a=0;
+    CGFloat h=0,s=0,b=0,a=0;
     
     if ([self respondsToSelector:@selector(getHue:saturation:brightness:alpha:)]) {
         [self getHue:&h saturation:&s brightness:&b alpha:&a];


### PR DESCRIPTION
Changed the (r,g, b, a) and (h, s, b, a) used in rgbArray, rgbaDictionary and hsbaArray, hsbaDictionary respectively from floats to CGFloats to silence incompatible pointer type error.

![screen shot 2014-01-05 at 6 04 23 pm](https://f.cloud.github.com/assets/3321592/1847658/0541374a-765f-11e3-8676-c37fcc4c90e4.png)
![screen shot 2014-01-05 at 6 04 53 pm](https://f.cloud.github.com/assets/3321592/1847659/054544e8-765f-11e3-88ba-f0c9efd8ec2b.png)
