### PR TITLE
Add AGEColor implementation for better performances

### DIFF
--- a/AGEColor.h
+++ b/AGEColor.h
@@ -1,0 +1,35 @@
+//
+// AGEColor.h
+//
+// Copyright (c) 2013 Alexander Edge (http://www.alexedge.co.uk)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#define AGEColorDefine(COLOR_NAME)    \
++ (UIColor *)COLOR_NAME;
+
+#define AGEColorImplement(COLOR_NAME,COLOR)    \
++ (UIColor *)COLOR_NAME{    \
+static UIColor* COLOR_NAME##_color;    \
+static dispatch_once_t COLOR_NAME##_onceToken;   \
+dispatch_once(&COLOR_NAME##_onceToken, ^{    \
+COLOR_NAME##_color = COLOR;  \
+}); \
+return COLOR_NAME##_color;  \
+}

--- a/AGEColor.h
+++ b/AGEColor.h
@@ -22,11 +22,11 @@
 // THE SOFTWARE.
 
 #define AGEColorDefine(COLOR_NAME)    \
-+ (UIColor *)COLOR_NAME;
++ (instancetype)COLOR_NAME;
 
 #define AGEColorImplement(COLOR_NAME,COLOR)    \
-+ (UIColor *)COLOR_NAME{    \
-static UIColor* COLOR_NAME##_color;    \
++ (instancetype)COLOR_NAME{    \
+static id COLOR_NAME##_color;    \
 static dispatch_once_t COLOR_NAME##_onceToken;   \
 dispatch_once(&COLOR_NAME##_onceToken, ^{    \
 COLOR_NAME##_color = COLOR;  \

--- a/Colours.h
+++ b/Colours.h
@@ -22,6 +22,7 @@
 
 #include "TargetConditionals.h"
 #include <Foundation/Foundation.h>
+#import "AGEColor.h"
 
 
 #pragma mark - Static String Keys
@@ -403,122 +404,122 @@ typedef NS_ENUM(NSInteger, ColorComparison) {
 
 #pragma mark - Colors
 // System Colors
-+ (instancetype)infoBlueColor;
-+ (instancetype)successColor;
-+ (instancetype)warningColor;
-+ (instancetype)dangerColor;
+AGEColorDefine(infoBlueColor);
+AGEColorDefine(successColor);
+AGEColorDefine(warningColor);
+AGEColorDefine(dangerColor);
 
 // Whites
-+ (instancetype)antiqueWhiteColor;
-+ (instancetype)oldLaceColor;
-+ (instancetype)ivoryColor;
-+ (instancetype)seashellColor;
-+ (instancetype)ghostWhiteColor;
-+ (instancetype)snowColor;
-+ (instancetype)linenColor;
+AGEColorDefine(antiqueWhiteColor);
+AGEColorDefine(oldLaceColor);
+AGEColorDefine(ivoryColor);
+AGEColorDefine(seashellColor);
+AGEColorDefine(ghostWhiteColor);
+AGEColorDefine(snowColor);
+AGEColorDefine(linenColor);
 
 // Grays
-+ (instancetype)black25PercentColor;
-+ (instancetype)black50PercentColor;
-+ (instancetype)black75PercentColor;
-+ (instancetype)warmGrayColor;
-+ (instancetype)coolGrayColor;
-+ (instancetype)charcoalColor;
+AGEColorDefine(black25PercentColor);
+AGEColorDefine(black50PercentColor);
+AGEColorDefine(black75PercentColor);
+AGEColorDefine(warmGrayColor);
+AGEColorDefine(coolGrayColor);
+AGEColorDefine(charcoalColor);
 
 // Blues
-+ (instancetype)tealColor;
-+ (instancetype)steelBlueColor;
-+ (instancetype)robinEggColor;
-+ (instancetype)pastelBlueColor;
-+ (instancetype)turquoiseColor;
-+ (instancetype)skyBlueColor;
-+ (instancetype)indigoColor;
-+ (instancetype)denimColor;
-+ (instancetype)blueberryColor;
-+ (instancetype)cornflowerColor;
-+ (instancetype)babyBlueColor;
-+ (instancetype)midnightBlueColor;
-+ (instancetype)fadedBlueColor;
-+ (instancetype)icebergColor;
-+ (instancetype)waveColor;
+AGEColorDefine(tealColor);
+AGEColorDefine(steelBlueColor);
+AGEColorDefine(robinEggColor);
+AGEColorDefine(pastelBlueColor);
+AGEColorDefine(turquoiseColor);
+AGEColorDefine(skyBlueColor);
+AGEColorDefine(indigoColor);
+AGEColorDefine(denimColor);
+AGEColorDefine(blueberryColor);
+AGEColorDefine(cornflowerColor);
+AGEColorDefine(babyBlueColor);
+AGEColorDefine(midnightBlueColor);
+AGEColorDefine(fadedBlueColor);
+AGEColorDefine(icebergColor);
+AGEColorDefine(waveColor);
 
 // Greens
-+ (instancetype)emeraldColor;
-+ (instancetype)grassColor;
-+ (instancetype)pastelGreenColor;
-+ (instancetype)seafoamColor;
-+ (instancetype)paleGreenColor;
-+ (instancetype)cactusGreenColor;
-+ (instancetype)chartreuseColor;
-+ (instancetype)hollyGreenColor;
-+ (instancetype)oliveColor;
-+ (instancetype)oliveDrabColor;
-+ (instancetype)moneyGreenColor;
-+ (instancetype)honeydewColor;
-+ (instancetype)limeColor;
-+ (instancetype)cardTableColor;
+AGEColorDefine(emeraldColor);
+AGEColorDefine(grassColor);
+AGEColorDefine(pastelGreenColor);
+AGEColorDefine(seafoamColor);
+AGEColorDefine(paleGreenColor);
+AGEColorDefine(cactusGreenColor);
+AGEColorDefine(chartreuseColor);
+AGEColorDefine(hollyGreenColor);
+AGEColorDefine(oliveColor);
+AGEColorDefine(oliveDrabColor);
+AGEColorDefine(moneyGreenColor);
+AGEColorDefine(honeydewColor);
+AGEColorDefine(limeColor);
+AGEColorDefine(cardTableColor);
 
 // Reds
-+ (instancetype)salmonColor;
-+ (instancetype)brickRedColor;
-+ (instancetype)easterPinkColor;
-+ (instancetype)grapefruitColor;
-+ (instancetype)pinkColor;
-+ (instancetype)indianRedColor;
-+ (instancetype)strawberryColor;
-+ (instancetype)coralColor;
-+ (instancetype)maroonColor;
-+ (instancetype)watermelonColor;
-+ (instancetype)tomatoColor;
-+ (instancetype)pinkLipstickColor;
-+ (instancetype)paleRoseColor;
-+ (instancetype)crimsonColor;
+AGEColorDefine(salmonColor);
+AGEColorDefine(brickRedColor);
+AGEColorDefine(easterPinkColor);
+AGEColorDefine(grapefruitColor);
+AGEColorDefine(pinkColor);
+AGEColorDefine(indianRedColor);
+AGEColorDefine(strawberryColor);
+AGEColorDefine(coralColor);
+AGEColorDefine(maroonColor);
+AGEColorDefine(watermelonColor);
+AGEColorDefine(tomatoColor);
+AGEColorDefine(pinkLipstickColor);
+AGEColorDefine(paleRoseColor);
+AGEColorDefine(crimsonColor);
 
 // Purples
-+ (instancetype)eggplantColor;
-+ (instancetype)pastelPurpleColor;
-+ (instancetype)palePurpleColor;
-+ (instancetype)coolPurpleColor;
-+ (instancetype)violetColor;
-+ (instancetype)plumColor;
-+ (instancetype)lavenderColor;
-+ (instancetype)raspberryColor;
-+ (instancetype)fuschiaColor;
-+ (instancetype)grapeColor;
-+ (instancetype)periwinkleColor;
-+ (instancetype)orchidColor;
+AGEColorDefine(eggplantColor);
+AGEColorDefine(pastelPurpleColor);
+AGEColorDefine(palePurpleColor);
+AGEColorDefine(coolPurpleColor);
+AGEColorDefine(violetColor);
+AGEColorDefine(plumColor);
+AGEColorDefine(lavenderColor);
+AGEColorDefine(raspberryColor);
+AGEColorDefine(fuschiaColor);
+AGEColorDefine(grapeColor);
+AGEColorDefine(periwinkleColor);
+AGEColorDefine(orchidColor);
 
 // Yellows
-+ (instancetype)goldenrodColor;
-+ (instancetype)yellowGreenColor;
-+ (instancetype)bananaColor;
-+ (instancetype)mustardColor;
-+ (instancetype)buttermilkColor;
-+ (instancetype)goldColor;
-+ (instancetype)creamColor;
-+ (instancetype)lightCreamColor;
-+ (instancetype)wheatColor;
-+ (instancetype)beigeColor;
+AGEColorDefine(goldenrodColor);
+AGEColorDefine(yellowGreenColor);
+AGEColorDefine(bananaColor);
+AGEColorDefine(mustardColor);
+AGEColorDefine(buttermilkColor);
+AGEColorDefine(goldColor);
+AGEColorDefine(creamColor);
+AGEColorDefine(lightCreamColor);
+AGEColorDefine(wheatColor);
+AGEColorDefine(beigeColor);
 
 // Oranges
-+ (instancetype)peachColor;
-+ (instancetype)burntOrangeColor;
-+ (instancetype)pastelOrangeColor;
-+ (instancetype)cantaloupeColor;
-+ (instancetype)carrotColor;
-+ (instancetype)mandarinColor;
+AGEColorDefine(peachColor);
+AGEColorDefine(burntOrangeColor);
+AGEColorDefine(pastelOrangeColor);
+AGEColorDefine(cantaloupeColor);
+AGEColorDefine(carrotColor);
+AGEColorDefine(mandarinColor);
 
 // Browns
-+ (instancetype)chiliPowderColor;
-+ (instancetype)burntSiennaColor;
-+ (instancetype)chocolateColor;
-+ (instancetype)coffeeColor;
-+ (instancetype)cinnamonColor;
-+ (instancetype)almondColor;
-+ (instancetype)eggshellColor;
-+ (instancetype)sandColor;
-+ (instancetype)mudColor;
-+ (instancetype)siennaColor;
-+ (instancetype)dustColor;
+AGEColorDefine(chiliPowderColor);
+AGEColorDefine(burntSiennaColor);
+AGEColorDefine(chocolateColor);
+AGEColorDefine(coffeeColor);
+AGEColorDefine(cinnamonColor);
+AGEColorDefine(almondColor);
+AGEColorDefine(eggshellColor);
+AGEColorDefine(sandColor);
+AGEColorDefine(mudColor);
+AGEColorDefine(siennaColor);
+AGEColorDefine(dustColor);
 
 @end

--- a/Colours.m
+++ b/Colours.m
@@ -701,518 +701,221 @@ static CGFloat (^RAD)(CGFloat) = ^CGFloat (CGFloat degree){
 
 
 #pragma mark - System Colors
-+ (instancetype)infoBlueColor
-{
-	return [[self class] colorWithR:47 G:112 B:225 A:1.0];
-}
+AGEColorImplement(infoBlueColor, [[self class] colorWithR:47 G:112 B:225 A:1.0]);
 
-+ (instancetype)successColor
-{
-	return [[self class] colorWithR:83 G:215 B:106 A:1.0];
-}
+AGEColorImplement(successColor, [[self class] colorWithR:83 G:215 B:106 A:1.0]);
 
-+ (instancetype)warningColor
-{
-	return [[self class] colorWithR:221 G:170 B:59 A:1.0];
-}
+AGEColorImplement(warningColor, [[self class] colorWithR:221 G:170 B:59 A:1.0]);
 
-+ (instancetype)dangerColor
-{
-	return [[self class] colorWithR:229 G:0 B:15 A:1.0];
-}
+AGEColorImplement(dangerColor, [[self class] colorWithR:229 G:0 B:15 A:1.0]);
 
 
 #pragma mark - Whites
-+ (instancetype)antiqueWhiteColor
-{
-	return [[self class] colorWithR:250 G:235 B:215 A:1.0];
-}
+AGEColorImplement(antiqueWhiteColor, [[self class] colorWithR:250 G:235 B:215 A:1.0]);
 
-+ (instancetype)oldLaceColor
-{
-	return [[self class] colorWithR:253 G:245 B:230 A:1.0];
-}
+AGEColorImplement(oldLaceColor, [[self class] colorWithR:253 G:245 B:230 A:1.0]);
 
-+ (instancetype)ivoryColor
-{
-	return [[self class] colorWithR:255 G:255 B:240 A:1.0];
-}
+AGEColorImplement(ivoryColor, [[self class] colorWithR:255 G:255 B:240 A:1.0]);
 
-+ (instancetype)seashellColor
-{
-	return [[self class] colorWithR:255 G:245 B:238 A:1.0];
-}
+AGEColorImplement(seashellColor, [[self class] colorWithR:255 G:245 B:238 A:1.0]);
 
-+ (instancetype)ghostWhiteColor
-{
-	return [[self class] colorWithR:248 G:248 B:255 A:1.0];
-}
+AGEColorImplement(ghostWhiteColor, [[self class] colorWithR:248 G:248 B:255 A:1.0]);
 
-+ (instancetype)snowColor
-{
-	return [[self class] colorWithR:255 G:250 B:250 A:1.0];
-}
+AGEColorImplement(snowColor, [[self class] colorWithR:255 G:250 B:250 A:1.0]);
 
-+ (instancetype)linenColor
-{
-	return [[self class] colorWithR:250 G:240 B:230 A:1.0];
-}
+AGEColorImplement(linenColor, [[self class] colorWithR:250 G:240 B:230 A:1.0]);
 
 
 #pragma mark - Grays
-+ (instancetype)black25PercentColor
-{
-	return [[self class] colorWithWhite:0.25 alpha:1.0];
-}
+AGEColorImplement(black25PercentColor, [[self class] colorWithWhite:0.25 alpha:1.0]);
 
-+ (instancetype)black50PercentColor
-{
-	return [[self class] colorWithWhite:0.5  alpha:1.0];
-}
+AGEColorImplement(black50PercentColor, [[self class] colorWithWhite:0.5  alpha:1.0]);
 
-+ (instancetype)black75PercentColor
-{
-	return [[self class] colorWithWhite:0.75 alpha:1.0];
-}
+AGEColorImplement(black75PercentColor, [[self class] colorWithWhite:0.75 alpha:1.0]);
 
-+ (instancetype)warmGrayColor
-{
-	return [[self class] colorWithR:133 G:117 B:112 A:1.0];
-}
+AGEColorImplement(warmGrayColor, [[self class] colorWithR:133 G:117 B:112 A:1.0]);
 
-+ (instancetype)coolGrayColor
-{
-	return [[self class] colorWithR:118 G:122 B:133 A:1.0];
-}
+AGEColorImplement(coolGrayColor, [[self class] colorWithR:118 G:122 B:133 A:1.0]);
 
-+ (instancetype)charcoalColor
-{
-	return [[self class] colorWithR:34 G:34 B:34 A:1.0];
-}
+AGEColorImplement(charcoalColor, [[self class] colorWithR:34 G:34 B:34 A:1.0]);
 
 
 #pragma mark - Blues
-+ (instancetype)tealColor
-{
-	return [[self class] colorWithR:28 G:160 B:170 A:1.0];
-}
+AGEColorImplement(tealColor, [[self class] colorWithR:28 G:160 B:170 A:1.0]);
 
-+ (instancetype)steelBlueColor
-{
-	return [[self class] colorWithR:103 G:153 B:170 A:1.0];
-}
+AGEColorImplement(steelBlueColor, [[self class] colorWithR:103 G:153 B:170 A:1.0]);
 
-+ (instancetype)robinEggColor
-{
-	return [[self class] colorWithR:141 G:218 B:247 A:1.0];
-}
+AGEColorImplement(robinEggColor, [[self class] colorWithR:141 G:218 B:247 A:1.0]);
 
-+ (instancetype)pastelBlueColor
-{
-	return [[self class] colorWithR:99 G:161 B:247 A:1.0];
-}
+AGEColorImplement(pastelBlueColor, [[self class] colorWithR:99 G:161 B:247 A:1.0]);
 
-+ (instancetype)turquoiseColor
-{
-	return [[self class] colorWithR:112 G:219 B:219 A:1.0];
-}
+AGEColorImplement(turquoiseColor, [[self class] colorWithR:112 G:219 B:219 A:1.0]);
 
-+ (instancetype)skyBlueColor
-{
-	return [[self class] colorWithR:0 G:178 B:238 A:1.0];
-}
+AGEColorImplement(skyBlueColor, [[self class] colorWithR:0 G:178 B:238 A:1.0]);
 
-+ (instancetype)indigoColor
-{
-	return [[self class] colorWithR:13 G:79 B:139 A:1.0];
-}
+AGEColorImplement(indigoColor, [[self class] colorWithR:13 G:79 B:139 A:1.0]);
 
-+ (instancetype)denimColor
-{
-	return [[self class] colorWithR:67 G:114 B:170 A:1.0];
-}
+AGEColorImplement(denimColor, [[self class] colorWithR:67 G:114 B:170 A:1.0]);
 
-+ (instancetype)blueberryColor
-{
-	return [[self class] colorWithR:89 G:113 B:173 A:1.0];
-}
+AGEColorImplement(blueberryColor, [[self class] colorWithR:89 G:113 B:173 A:1.0]);
 
-+ (instancetype)cornflowerColor
-{
-	return [[self class] colorWithR:100 G:149 B:237 A:1.0];
-}
+AGEColorImplement(cornflowerColor, [[self class] colorWithR:100 G:149 B:237 A:1.0]);
 
-+ (instancetype)babyBlueColor
-{
-	return [[self class] colorWithR:190 G:220 B:230 A:1.0];
-}
+AGEColorImplement(babyBlueColor, [[self class] colorWithR:190 G:220 B:230 A:1.0]);
 
-+ (instancetype)midnightBlueColor
-{
-	return [[self class] colorWithR:13 G:26 B:35 A:1.0];
-}
+AGEColorImplement(midnightBlueColor, [[self class] colorWithR:13 G:26 B:35 A:1.0]);
 
-+ (instancetype)fadedBlueColor
-{
-	return [[self class] colorWithR:23 G:137 B:155 A:1.0];
-}
+AGEColorImplement(fadedBlueColor, [[self class] colorWithR:23 G:137 B:155 A:1.0]);
 
-+ (instancetype)icebergColor
-{
-	return [[self class] colorWithR:200 G:213 B:219 A:1.0];
-}
+AGEColorImplement(icebergColor, [[self class] colorWithR:200 G:213 B:219 A:1.0]);
 
-+ (instancetype)waveColor
-{
-	return [[self class] colorWithR:102 G:169 B:251 A:1.0];
-}
+AGEColorImplement(waveColor, [[self class] colorWithR:102 G:169 B:251 A:1.0]);
 
 
 #pragma mark - Greens
-+ (instancetype)emeraldColor
-{
-	return [[self class] colorWithR:1 G:152 B:117 A:1.0];
-}
+AGEColorImplement(emeraldColor, [[self class] colorWithR:1 G:152 B:117 A:1.0]);
 
-+ (instancetype)grassColor
-{
-	return [[self class] colorWithR:99 G:214 B:74 A:1.0];
-}
+AGEColorImplement(grassColor, [[self class] colorWithR:99 G:214 B:74 A:1.0]);
 
-+ (instancetype)pastelGreenColor
-{
-	return [[self class] colorWithR:126 G:242 B:124 A:1.0];
-}
+AGEColorImplement(pastelGreenColor, [[self class] colorWithR:126 G:242 B:124 A:1.0]);
 
-+ (instancetype)seafoamColor
-{
-	return [[self class] colorWithR:77 G:226 B:140 A:1.0];
-}
+AGEColorImplement(seafoamColor, [[self class] colorWithR:77 G:226 B:140 A:1.0]);
 
-+ (instancetype)paleGreenColor
-{
-	return [[self class] colorWithR:176 G:226 B:172 A:1.0];
-}
+AGEColorImplement(paleGreenColor, [[self class] colorWithR:176 G:226 B:172 A:1.0]);
 
-+ (instancetype)cactusGreenColor
-{
-	return [[self class] colorWithR:99 G:111 B:87 A:1.0];
-}
+AGEColorImplement(cactusGreenColor, [[self class] colorWithR:99 G:111 B:87 A:1.0]);
 
-+ (instancetype)chartreuseColor
-{
-	return [[self class] colorWithR:69 G:139 B:0 A:1.0];
-}
+AGEColorImplement(chartreuseColor, [[self class] colorWithR:69 G:139 B:0 A:1.0]);
 
-+ (instancetype)hollyGreenColor
-{
-	return [[self class] colorWithR:32 G:87 B:14 A:1.0];
-}
+AGEColorImplement(hollyGreenColor, [[self class] colorWithR:32 G:87 B:14 A:1.0]);
 
-+ (instancetype)oliveColor
-{
-	return [[self class] colorWithR:91 G:114 B:34 A:1.0];
-}
+AGEColorImplement(oliveColor, [[self class] colorWithR:91 G:114 B:34 A:1.0]);
 
-+ (instancetype)oliveDrabColor
-{
-	return [[self class] colorWithR:107 G:142 B:35 A:1.0];
-}
+AGEColorImplement(oliveDrabColor, [[self class] colorWithR:107 G:142 B:35 A:1.0]);
 
-+ (instancetype)moneyGreenColor
-{
-	return [[self class] colorWithR:134 G:198 B:124 A:1.0];
-}
+AGEColorImplement(moneyGreenColor, [[self class] colorWithR:134 G:198 B:124 A:1.0]);
 
-+ (instancetype)honeydewColor
-{
-	return [[self class] colorWithR:216 G:255 B:231 A:1.0];
-}
+AGEColorImplement(honeydewColor, [[self class] colorWithR:216 G:255 B:231 A:1.0]);
 
-+ (instancetype)limeColor
-{
-	return [[self class] colorWithR:56 G:237 B:56 A:1.0];
-}
+AGEColorImplement(limeColor, [[self class] colorWithR:56 G:237 B:56 A:1.0]);
 
-+ (instancetype)cardTableColor
-{
-	return [[self class] colorWithR:87 G:121 B:107 A:1.0];
-}
+AGEColorImplement(cardTableColor, [[self class] colorWithR:87 G:121 B:107 A:1.0]);
 
 
 #pragma mark - Reds
-+ (instancetype)salmonColor
-{
-	return [[self class] colorWithR:233 G:87 B:95 A:1.0];
-}
+AGEColorImplement(salmonColor, [[self class] colorWithR:233 G:87 B:95 A:1.0]);
 
-+ (instancetype)brickRedColor
-{
-	return [[self class] colorWithR:151 G:27 B:16 A:1.0];
-}
+AGEColorImplement(brickRedColor, [[self class] colorWithR:151 G:27 B:16 A:1.0]);
 
-+ (instancetype)easterPinkColor
-{
-	return [[self class] colorWithR:241 G:167 B:162 A:1.0];
-}
+AGEColorImplement(easterPinkColor, [[self class] colorWithR:241 G:167 B:162 A:1.0]);
 
-+ (instancetype)grapefruitColor
-{
-	return [[self class] colorWithR:228 G:31 B:54 A:1.0];
-}
+AGEColorImplement(grapefruitColor, [[self class] colorWithR:228 G:31 B:54 A:1.0]);
 
-+ (instancetype)pinkColor
-{
-	return [[self class] colorWithR:255 G:95 B:154 A:1.0];
-}
+AGEColorImplement(pinkColor, [[self class] colorWithR:255 G:95 B:154 A:1.0]);
 
-+ (instancetype)indianRedColor
-{
-	return [[self class] colorWithR:205 G:92 B:92 A:1.0];
-}
+AGEColorImplement(indianRedColor, [[self class] colorWithR:205 G:92 B:92 A:1.0]);
 
-+ (instancetype)strawberryColor
-{
-	return [[self class] colorWithR:190 G:38 B:37 A:1.0];
-}
+AGEColorImplement(strawberryColor, [[self class] colorWithR:190 G:38 B:37 A:1.0]);
 
-+ (instancetype)coralColor
-{
-	return [[self class] colorWithR:240 G:128 B:128 A:1.0];
-}
+AGEColorImplement(coralColor, [[self class] colorWithR:240 G:128 B:128 A:1.0]);
 
-+ (instancetype)maroonColor
-{
-	return [[self class] colorWithR:80 G:4 B:28 A:1.0];
-}
+AGEColorImplement(maroonColor, [[self class] colorWithR:80 G:4 B:28 A:1.0]);
 
-+ (instancetype)watermelonColor
-{
-	return [[self class] colorWithR:242 G:71 B:63 A:1.0];
-}
+AGEColorImplement(watermelonColor, [[self class] colorWithR:242 G:71 B:63 A:1.0]);
 
-+ (instancetype)tomatoColor
-{
-	return [[self class] colorWithR:255 G:99 B:71 A:1.0];
-}
+AGEColorImplement(tomatoColor, [[self class] colorWithR:255 G:99 B:71 A:1.0]);
 
-+ (instancetype)pinkLipstickColor
-{
-	return [[self class] colorWithR:255 G:105 B:180 A:1.0];
-}
+AGEColorImplement(pinkLipstickColor, [[self class] colorWithR:255 G:105 B:180 A:1.0]);
 
-+ (instancetype)paleRoseColor
-{
-	return [[self class] colorWithR:255 G:228 B:225 A:1.0];
-}
+AGEColorImplement(paleRoseColor, [[self class] colorWithR:255 G:228 B:225 A:1.0]);
 
-+ (instancetype)crimsonColor
-{
-	return [[self class] colorWithR:187 G:18 B:36 A:1.0];
-}
+AGEColorImplement(crimsonColor, [[self class] colorWithR:187 G:18 B:36 A:1.0]);
 
 
 #pragma mark - Purples
-+ (instancetype)eggplantColor
-{
-	return [[self class] colorWithR:105 G:5 B:98 A:1.0];
-}
+AGEColorImplement(eggplantColor, [[self class] colorWithR:105 G:5 B:98 A:1.0]);
 
-+ (instancetype)pastelPurpleColor
-{
-	return [[self class] colorWithR:207 G:100 B:235 A:1.0];
-}
+AGEColorImplement(pastelPurpleColor, [[self class] colorWithR:207 G:100 B:235 A:1.0]);
 
-+ (instancetype)palePurpleColor
-{
-	return [[self class] colorWithR:229 G:180 B:235 A:1.0];
-}
+AGEColorImplement(palePurpleColor, [[self class] colorWithR:229 G:180 B:235 A:1.0]);
 
-+ (instancetype)coolPurpleColor
-{
-	return [[self class] colorWithR:140 G:93 B:228 A:1.0];
-}
+AGEColorImplement(coolPurpleColor, [[self class] colorWithR:140 G:93 B:228 A:1.0]);
 
-+ (instancetype)violetColor
-{
-	return [[self class] colorWithR:191 G:95 B:255 A:1.0];
-}
+AGEColorImplement(violetColor, [[self class] colorWithR:191 G:95 B:255 A:1.0]);
 
-+ (instancetype)plumColor
-{
-	return [[self class] colorWithR:139 G:102 B:139 A:1.0];
-}
+AGEColorImplement(plumColor, [[self class] colorWithR:139 G:102 B:139 A:1.0]);
 
-+ (instancetype)lavenderColor
-{
-	return [[self class] colorWithR:204 G:153 B:204 A:1.0];
-}
+AGEColorImplement(lavenderColor, [[self class] colorWithR:204 G:153 B:204 A:1.0]);
 
-+ (instancetype)raspberryColor
-{
-	return [[self class] colorWithR:135 G:38 B:87 A:1.0];
-}
+AGEColorImplement(raspberryColor, [[self class] colorWithR:135 G:38 B:87 A:1.0]);
 
-+ (instancetype)fuschiaColor
-{
-	return [[self class] colorWithR:255 G:20 B:147 A:1.0];
-}
+AGEColorImplement(fuschiaColor, [[self class] colorWithR:255 G:20 B:147 A:1.0]);
 
-+ (instancetype)grapeColor
-{
-	return [[self class] colorWithR:54 G:11 B:88 A:1.0];
-}
+AGEColorImplement(grapeColor, [[self class] colorWithR:54 G:11 B:88 A:1.0]);
 
-+ (instancetype)periwinkleColor
-{
-	return [[self class] colorWithR:135 G:159 B:237 A:1.0];
-}
+AGEColorImplement(periwinkleColor, [[self class] colorWithR:135 G:159 B:237 A:1.0]);
 
-+ (instancetype)orchidColor
-{
-	return [[self class] colorWithR:218 G:112 B:214 A:1.0];
-}
+AGEColorImplement(orchidColor, [[self class] colorWithR:218 G:112 B:214 A:1.0]);
 
 
 #pragma mark - Yellows
-+ (instancetype)goldenrodColor
-{
-	return [[self class] colorWithR:215 G:170 B:51 A:1.0];
-}
+AGEColorImplement(goldenrodColor, [[self class] colorWithR:215 G:170 B:51 A:1.0]);
 
-+ (instancetype)yellowGreenColor
-{
-	return [[self class] colorWithR:192 G:242 B:39 A:1.0];
-}
+AGEColorImplement(yellowGreenColor, [[self class] colorWithR:192 G:242 B:39 A:1.0]);
 
-+ (instancetype)bananaColor
-{
-	return [[self class] colorWithR:229 G:227 B:58 A:1.0];
-}
+AGEColorImplement(bananaColor, [[self class] colorWithR:229 G:227 B:58 A:1.0]);
 
-+ (instancetype)mustardColor
-{
-	return [[self class] colorWithR:205 G:171 B:45 A:1.0];
-}
+AGEColorImplement(mustardColor, [[self class] colorWithR:205 G:171 B:45 A:1.0]);
 
-+ (instancetype)buttermilkColor
-{
-	return [[self class] colorWithR:254 G:241 B:181 A:1.0];
-}
+AGEColorImplement(buttermilkColor, [[self class] colorWithR:254 G:241 B:181 A:1.0]);
 
-+ (instancetype)goldColor
-{
-	return [[self class] colorWithR:139 G:117 B:18 A:1.0];
-}
+AGEColorImplement(goldColor, [[self class] colorWithR:139 G:117 B:18 A:1.0]);
 
-+ (instancetype)creamColor
-{
-	return [[self class] colorWithR:240 G:226 B:187 A:1.0];
-}
+AGEColorImplement(creamColor, [[self class] colorWithR:240 G:226 B:187 A:1.0]);
 
-+ (instancetype)lightCreamColor
-{
-	return [[self class] colorWithR:240 G:238 B:215 A:1.0];
-}
+AGEColorImplement(lightCreamColor, [[self class] colorWithR:240 G:238 B:215 A:1.0]);
 
-+ (instancetype)wheatColor
-{
-	return [[self class] colorWithR:240 G:238 B:215 A:1.0];
-}
+AGEColorImplement(wheatColor, [[self class] colorWithR:240 G:238 B:215 A:1.0]);
 
-+ (instancetype)beigeColor
-{
-	return [[self class] colorWithR:245 G:245 B:220 A:1.0];
-}
+AGEColorImplement(beigeColor, [[self class] colorWithR:245 G:245 B:220 A:1.0]);
 
 
 #pragma mark - Oranges
-+ (instancetype)peachColor
-{
-	return [[self class] colorWithR:242 G:187 B:97 A:1.0];
-}
+AGEColorImplement(peachColor, [[self class] colorWithR:242 G:187 B:97 A:1.0]);
 
-+ (instancetype)burntOrangeColor
-{
-	return [[self class] colorWithR:184 G:102 B:37 A:1.0];
-}
+AGEColorImplement(burntOrangeColor, [[self class] colorWithR:184 G:102 B:37 A:1.0]);
 
-+ (instancetype)pastelOrangeColor
-{
-	return [[self class] colorWithR:248 G:197 B:143 A:1.0];
-}
+AGEColorImplement(pastelOrangeColor, [[self class] colorWithR:248 G:197 B:143 A:1.0]);
 
-+ (instancetype)cantaloupeColor
-{
-	return [[self class] colorWithR:250 G:154 B:79 A:1.0];
-}
+AGEColorImplement(cantaloupeColor, [[self class] colorWithR:250 G:154 B:79 A:1.0]);
 
-+ (instancetype)carrotColor
-{
-	return [[self class] colorWithR:237 G:145 B:33 A:1.0];
-}
+AGEColorImplement(carrotColor, [[self class] colorWithR:237 G:145 B:33 A:1.0]);
 
-+ (instancetype)mandarinColor
-{
-	return [[self class] colorWithR:247 G:145 B:55 A:1.0];
-}
+AGEColorImplement(mandarinColor, [[self class] colorWithR:247 G:145 B:55 A:1.0]);
 
 
 #pragma mark - Browns
-+ (instancetype)chiliPowderColor
-{
-	return [[self class] colorWithR:199 G:63 B:23 A:1.0];
-}
+AGEColorImplement(chiliPowderColor, [[self class] colorWithR:199 G:63 B:23 A:1.0]);
 
-+ (instancetype)burntSiennaColor
-{
-	return [[self class] colorWithR:138 G:54 B:15 A:1.0];
-}
+AGEColorImplement(burntSiennaColor, [[self class] colorWithR:138 G:54 B:15 A:1.0]);
 
-+ (instancetype)chocolateColor
-{
-	return [[self class] colorWithR:94 G:38 B:5 A:1.0];
-}
+AGEColorImplement(chocolateColor, [[self class] colorWithR:94 G:38 B:5 A:1.0]);
 
-+ (instancetype)coffeeColor
-{
-	return [[self class] colorWithR:141 G:60 B:15 A:1.0];
-}
+AGEColorImplement(coffeeColor, [[self class] colorWithR:141 G:60 B:15 A:1.0]);
 
-+ (instancetype)cinnamonColor
-{
-	return [[self class] colorWithR:123 G:63 B:9 A:1.0];
-}
+AGEColorImplement(cinnamonColor, [[self class] colorWithR:123 G:63 B:9 A:1.0]);
 
-+ (instancetype)almondColor
-{
-	return [[self class] colorWithR:196 G:142 B:72 A:1.0];
-}
+AGEColorImplement(almondColor, [[self class] colorWithR:196 G:142 B:72 A:1.0]);
 
-+ (instancetype)eggshellColor
-{
-	return [[self class] colorWithR:252 G:230 B:201 A:1.0];
-}
+AGEColorImplement(eggshellColor, [[self class] colorWithR:252 G:230 B:201 A:1.0]);
 
-+ (instancetype)sandColor
-{
-	return [[self class] colorWithR:222 G:182 B:151 A:1.0];
-}
+AGEColorImplement(sandColor, [[self class] colorWithR:222 G:182 B:151 A:1.0]);
 
-+ (instancetype)mudColor
-{
-	return [[self class] colorWithR:70 G:45 B:29 A:1.0];
-}
+AGEColorImplement(mudColor, [[self class] colorWithR:70 G:45 B:29 A:1.0]);
 
-+ (instancetype)siennaColor
-{
-	return [[self class] colorWithR:160 G:82 B:45 A:1.0];
-}
+AGEColorImplement(siennaColor, [[self class] colorWithR:160 G:82 B:45 A:1.0]);
 
-+ (instancetype)dustColor
-{
-	return [[self class] colorWithR:236 G:214 B:197 A:1.0];
-}
+AGEColorImplement(dustColor, [[self class] colorWithR:236 G:214 B:197 A:1.0]);
 
 
 #pragma mark - Private

--- a/ColoursDemo/ColoursDemo.xcodeproj/project.pbxproj
+++ b/ColoursDemo/ColoursDemo.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		44C791CE182586210059592D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		44C791D0182586210059592D /* ColoursDemo_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ColoursDemo_Tests.m; sourceTree = "<group>"; };
 		44C791D2182586210059592D /* ColoursDemo Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ColoursDemo Tests-Prefix.pch"; sourceTree = "<group>"; };
+		6520D8F01A83D114003B6BF0 /* AGEColor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AGEColor.h; path = ../../AGEColor.h; sourceTree = "<group>"; };
 		B6120DC7188DF0B60037E5EC /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		B6120DC8188DF0B60037E5EC /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		B65430821A4FAEAD00A28A8A /* ColoursDemo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ColoursDemo-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -129,6 +130,7 @@
 		44C791B91823CB070059592D /* UIColor Category (Class Extension) */ = {
 			isa = PBXGroup;
 			children = (
+				6520D8F01A83D114003B6BF0 /* AGEColor.h */,
 				1E4C42E81851434200F323C1 /* Colours.h */,
 				1E4C42E91851434200F323C1 /* Colours.m */,
 				B65430831A4FAEAE00A28A8A /* Colours.swift */,


### PR DESCRIPTION
Hi. This is nitpicking really, but as you can read in this [blog post](http://blog.alexedge.co.uk/speeding-up-uicolor-categories/) when generating UI/NSColor you can improve performances of subsequent calls by _caching_ the resulting object. This PR adds the macro calls to generate the colors just once. 
Cheers :beers: 