### PR TITLE
Fixed #33 semantic warnings. Updated podspec.

### DIFF
--- a/Colours.m
+++ b/Colours.m
@@ -660,14 +660,14 @@ static CGFloat (^RAD)(CGFloat) = ^CGFloat (CGFloat degree){
     hPrime1 = fmodf(hPrime1, RAD(360.0));
     hPrime2 = fmodf(hPrime2, RAD(360.0));
     CGFloat deltahPrime = 0;
-    if (fabsf(hPrime1 - hPrime2) <= RAD(180.0)) {
+    if (fabs(hPrime1 - hPrime2) <= RAD(180.0)) {
         deltahPrime = hPrime2 - hPrime1;
     }
     else {
         deltahPrime = (hPrime2 <= hPrime1) ? hPrime2 - hPrime1 + RAD(360.0) : hPrime2 - hPrime1 - RAD(360.0);
     }
     CGFloat deltaHPrime = 2 * sqrt(cPrime1*cPrime2) * sin(deltahPrime/2);
-    CGFloat meanHPrime = (fabsf(hPrime1 - hPrime2) <= RAD(180.0)) ? (hPrime1 + hPrime2)/2 : (hPrime1 + hPrime2 + RAD(360.0))/2;
+    CGFloat meanHPrime = (fabs(hPrime1 - hPrime2) <= RAD(180.0)) ? (hPrime1 + hPrime2)/2 : (hPrime1 + hPrime2 + RAD(360.0))/2;
     CGFloat T = 1 - 0.17*cos(meanHPrime - RAD(30.0)) + 0.24*cos(2*meanHPrime)+0.32*cos(3*meanHPrime + RAD(6.0)) - 0.20*cos(4*meanHPrime - RAD(63.0));
     sL = 1 + (0.015 * pow((meanL - 50), 2))/sqrt(20 + pow((meanL - 50), 2));
     sC = 1 + 0.045*cMeanPrime;

--- a/Colours.podspec
+++ b/Colours.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Colours'
-  s.version      = '5.6.1'
+  s.version      = '5.6.2'
   s.summary      = '100s of beautiful, predefined Colors and Color methods. Works for iOS/OSX.'
   s.author = {
     'Ben Gordon' => 'brgordon@ua.edu'


### PR DESCRIPTION
Fix for issue #33 

* Project/Pods/Colours/Colours.m:663:9: Absolute value function 'fabsf' given an argument of type 'double' but has parameter of type 'float' which may cause truncation of value.

* Project/Pods/Colours/Colours.m:670:27: Absolute value function 'fabsf' given an argument of type 'double' but has parameter of type 'float' which may cause truncation of value