### PR TITLE
change access control to public from internal

### DIFF
--- a/Colours.swift
+++ b/Colours.swift
@@ -15,7 +15,7 @@ import AppKit
 public typealias Color = NSColor
 #endif
 
-extension Color {
+public extension Color {
     // MARK: - Closure
     typealias TransformBlock = CGFloat -> CGFloat
     


### PR DESCRIPTION
I tried to use the Colours/Swift installed by cocoapods.

But I cannot use any methods. Because access control is internal.

> If you extend a public or internal type, any new type members you add will have a default access level of internal.

[The Swift Programming Language (Swift 2.1): Access Control](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID25)

So, I added `public`

My Environment is

- swift 2.1
- Xcode 7.1.1
- cocoapods 0.39.0